### PR TITLE
A few small changes to simplify deployments

### DIFF
--- a/kubernetes/servicecontrol-audit.statefulset.yaml
+++ b/kubernetes/servicecontrol-audit.statefulset.yaml
@@ -77,6 +77,7 @@ spec:
             - name: api
               containerPort: 44444
               protocol: TCP
+          args: ["--setup-and-run"]
           env:
             - name: RABBITMQ_HOST
               valueFrom:
@@ -114,37 +115,13 @@ spec:
           volumeMounts:
             - name: audit-db-data
               mountPath: /var/lib/ravendb/data
-        - name: wait-for-ravendb
-          image: curlimages/curl:latest
-          command:
-            [
-              "curl",
-              "-o",
-              "ping.json",
-              "http://localhost:8080/admin/debug/node/ping",
-            ]
-        - name: init-servicecontrol-audit
-          image: particular/servicecontrol-audit:latest
-          args: ["--setup"]
-          env:
-            - name: RABBITMQ_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: host
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: username
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: password
-            - name: TRANSPORTTYPE
-              value: "RabbitMQ.QuorumConventionalRouting"
-            - name: CONNECTIONSTRING
-              value: "Host=$(RABBITMQ_HOST);username=$(RABBITMQ_USERNAME);Password=$(RABBITMQ_PASSWORD);"
-            - name: RAVENDB_CONNECTIONSTRING
-              value: http://localhost:8080
+          readinessProbe:
+            httpGet:
+              path: "/admin/debug/node/ping"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 20

--- a/kubernetes/servicecontrol-error.statefulset.yaml
+++ b/kubernetes/servicecontrol-error.statefulset.yaml
@@ -77,6 +77,7 @@ spec:
             - name: api
               containerPort: 33333
               protocol: TCP
+          args: ["--setup-and-run"]
           env:
             - name: RABBITMQ_HOST
               valueFrom:
@@ -116,37 +117,13 @@ spec:
           volumeMounts:
             - name: error-db-data
               mountPath: /var/lib/ravendb/data
-        - name: wait-for-ravendb
-          image: curlimages/curl:latest
-          command:
-            [
-              "curl",
-              "-o",
-              "ping.json",
-              "http://localhost:8080/admin/debug/node/ping",
-            ]
-        - name: init-servicecontrol-error
-          image: particular/servicecontrol:latest
-          args: ["--setup"]
-          env:
-            - name: RABBITMQ_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: host
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: username
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: password
-            - name: TRANSPORTTYPE
-              value: "RabbitMQ.QuorumConventionalRouting"
-            - name: CONNECTIONSTRING
-              value: "Host=$(RABBITMQ_HOST);username=$(RABBITMQ_USERNAME);Password=$(RABBITMQ_PASSWORD);"
-            - name: RAVENDB_CONNECTIONSTRING
-              value: http://localhost:8080
+          readinessProbe:
+            httpGet:
+              path: "/admin/debug/node/ping"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 20

--- a/kubernetes/servicecontrol-monitoring.deployment.yaml
+++ b/kubernetes/servicecontrol-monitoring.deployment.yaml
@@ -33,30 +33,7 @@ spec:
       containers:
         - name: servicecontrol-monitoring
           image: particular/servicecontrol-monitoring:latest
-          env:
-            - name: RABBITMQ_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: host
-            - name: RABBITMQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: username
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: rabbitmq-default-user
-                  key: password
-            - name: TRANSPORTTYPE
-              value: "RabbitMQ.QuorumConventionalRouting"
-            - name: CONNECTIONSTRING
-              value: "Host=$(RABBITMQ_HOST);username=$(RABBITMQ_USERNAME);Password=$(RABBITMQ_PASSWORD);"
-      initContainers:
-        - name: init-servicecontrol-monitoring
-          image: particular/servicecontrol-monitoring:latest
-          args: ["--setup"]
+          args: ["--setup-and-run"]
           env:
             - name: RABBITMQ_HOST
               valueFrom:


### PR DESCRIPTION
We switched to using readiness probe on RavenDB containers, as mentioned in the [documentation](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/#sidecar-containers-and-pod-lifecycle).
Changed to use `--setup-and-run` arg instead of extra initContainer, given that `setup` is idempotent. We actually do this in the [bicep example](https://github.com/Particular/PlatformContainerExamples/blob/main/azure-container-apps/main.bicep) and as far as I know, it has caused no issues.