### PR TITLE
Bug fix: Error instance deployment template won't generate a value for SERVICECONTROL_REMOTEINSTANCES environment variable with the list of urls to available audit instances 

### DIFF
--- a/helm/templates/error/deployment.yaml
+++ b/helm/templates/error/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: PARTICULARSOFTWARE_LICENSE
               value: {{ . | quote }}
             {{- end }}
-            {{- if .Values.error.auditInstances }}
+            {{- if .Values.audit.instances }}
             - name: SERVICECONTROL_REMOTEINSTANCES
               value: {{ include "particular.error.auditInstances" . | squote }}
             {{- end }}  


### PR DESCRIPTION
The if validation for the array of audit instances was preventing the helper function from being invoked in order to generate the value for the environment variable [SERVICECONTROL_REMOTEINSTANCES](https://docs.particular.net/servicecontrol/servicecontrol-instances/configuration#host-settings-servicecontrolremoteinstances) 

